### PR TITLE
Fix install by updating the url

### DIFF
--- a/git-heatmap.rb
+++ b/git-heatmap.rb
@@ -1,8 +1,8 @@
 class GitHeatmap < Formula
   desc "Heatmap of oft-edited files"
   homepage "https://github.com/jez/git-heatmap"
-  url "https://github.com/jez/git-heatmap/archive/0.10.3.zip"
-  sha256 "e9562f6797ebdf2c0d1d64a7e453af0d97c48a6f7062b8a2f433c8e067606cad"
+  url "https://github.com/jez/git-heatmap/archive/0.10.3.tar.gz"
+  sha256 "c8c25da36de5295dc9e06033999068b531b4b9c45f36743f9206a9d42ba4420e"
 
   def install
     bin.install "git-heatmap"


### PR DESCRIPTION
Previously the install via Homebrew failed:

```
==> Installing git-heatmap from jez/formulae
==> Downloading https://github.com/jez/git-heatmap/archive/0.10.3.zip
==> Downloading from https://codeload.github.com/jez/git-heatmap/zip/0.10.3

curl: (52) Empty reply from server
Error: Failed to download resource "git-heatmap"
Download failed: https://github.com/jez/git-heatmap/archive/0.10.3.zip
```
Switching to the .tar.gz instead solved the problem for me.